### PR TITLE
Fix const accesor of Data<T>

### DIFF
--- a/include/modbuspp/data.h
+++ b/include/modbuspp/data.h
@@ -82,7 +82,7 @@ namespace Modbus {
       /**
        * @overload
        */
-      operator T&() const {
+      operator const T&() const {
         return m_value;
       }
 


### PR DESCRIPTION
This PR fixes const conversion of `Data<T>` to `T`. It was trying to return a non-const reference from a const member function. With this change, the member returns a const-reference.