### PR TITLE
modified so parity bit can be N in Rtu

### DIFF
--- a/src/rtulayer.cpp
+++ b/src/rtulayer.cpp
@@ -247,7 +247,7 @@ namespace Modbus {
   // ---------------------------------------------------------------------------
   // static
   char RtuLayer::parity (const std::string & settings) {
-    char p = 'E';
+    char p = 'N';
     size_t s = settings.length();
 
     if (s >= 2) {


### PR DESCRIPTION
I have made very little change in your rtulayer.cpp so it is possible to enable none parity bit. Thanks for your great work in this library