### PR TITLE
rtu layer: fix parsing of serial stop bits values

### DIFF
--- a/include/modbuspp/data.h
+++ b/include/modbuspp/data.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <stdexcept>
 #include <cstdio>     // printf
 #include <cstring>    // memcpy ...
 #include <array>

--- a/include/modbuspp/rtulayer.h
+++ b/include/modbuspp/rtulayer.h
@@ -169,23 +169,22 @@ namespace Modbus {
 
       /**
        * @brief Extracts the baudrate from a settings string.
-       * @return the baudrate found. if no value is found, returns the default
-       * value, ie 19200.
+       * @return the baudrate found. If no valid value is found, an exception is thrown.
        */
       static int baud (const std::string & settings);
 
       /**
        * @brief Extracts the parity from a settings string.
-       * @return the parity found. if no value is found, returns the default
-       * value, ie E for Even parity.
+       * @return the parity found. If no valid value is found, an exception is thrown.
        */
       static char parity (const std::string & settings);
 
       /**
        * @brief Return the stop bits from a settings string.
        *
-       * @return the number returned is determined based on the parity found.
-       * If the parity is None, this function returns 2, otherwise returns 1.
+       * @return the number of stop bits.
+       * It is parsed from the last character of the settings string.
+       * If the last character is neither '1' or '2' an exception is thrown.
        */
       static int stop (const std::string & settings);
       

--- a/src/rtulayer.cpp
+++ b/src/rtulayer.cpp
@@ -234,40 +234,48 @@ namespace Modbus {
   // ---------------------------------------------------------------------------
   // static
   int RtuLayer::baud (const std::string & settings) {
-    int b;
     try {
-      b = std::stoi (settings);
+      return std::stoi (settings);
     }
     catch (...) {
-      b = 19200;
+      throw std::invalid_argument ("RtuLayer settings\"" + settings + "\" has an invalid baud rate setting.");
     }
-    return b;
   }
 
   // ---------------------------------------------------------------------------
   // static
   char RtuLayer::parity (const std::string & settings) {
-    char p = 'N';
     size_t s = settings.length();
 
     if (s >= 2) {
       char c = settings[s - 2];
-      if ( (c == 'E') || (c == 'O')) {
-        return c;
+      switch (c) {
+        case 'N':
+        case 'E':
+        case 'O':
+          return c;
       }
     }
-    return p;
+
+    throw std::invalid_argument ("RtuLayer settings\"" + settings + "\" has an invalid parity setting.");
   }
 
   // ---------------------------------------------------------------------------
   // static
   int RtuLayer::stop (const std::string & settings) {
+    size_t s = settings.length();
 
-    if (parity (settings) == 'N') {
-
-      return 2;
+    if (s >= 3) {
+      char c = settings[s - 1];
+      switch (c) {
+        case '1':
+          return 1;
+        case '2':
+          return 2;
+      }
     }
-    return 1;
+
+    throw std::invalid_argument ("RtuLayer settings\"" + settings + "\" has an invalid stop bit setting.");
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Up until now, the stop bits value was hard coded to be 2 if the parity mode was set to none or 1 if the parity mode was set to even or odd.

So a setting of "115200E1" would result in a stop bit value of 1. But "115200E2" would result also in a stop bit value of 1. And "115200N1" would result in a stop bit value of 2.

This is not a restriction of libmodbus. The library supports all these modes just fine. In fact they are using 115200N1 in the documentation for modbus_new_rtu().

Rather this is a bug in the string parsing that libmodbuspp introduces in its constructor.
libmodbus has no string parsing in modbus_new_rtu() and takes in the arguments as parameters directly.

Fixes: b0f3dc4be5e82729825158ca651657afe1f6380b